### PR TITLE
Fix plugin path resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/matejkrajcovic/babel-plugin-superstrict#readme",
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.17",
+    "babel-cli": "^6.6.4",
+    "babel-core": "^6.6.4",
     "babel-eslint": "^5.0.0-beta6",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",

--- a/test/babelify.js
+++ b/test/babelify.js
@@ -5,7 +5,7 @@ export default function babelify(sourceFileName) {
     babelrc: false,
     presets: ['es2015'],
     plugins: [
-      ['../lib', {
+      ['../../lib', {
         'safeGetFilePath': '../lib/safe_get.js',
         'directivePolicy': 'opt in'
       }]


### PR DESCRIPTION
Since [v6.6.4](https://github.com/babel/babel/releases/tag/v6.6.4) of babel-core plugin paths are relative place of declaration (mostly .babelrc) not process.pwd(). In case of our test runner paths were relative to test/eval_tests.